### PR TITLE
Fixed bug in __init__.py line 294 (NoneType not iterable).

### DIFF
--- a/pygeoip/__init__.py
+++ b/pygeoip/__init__.py
@@ -291,8 +291,8 @@ class GeoIP(GeoIPBase):
 
         elif self._databaseType in (const.CITY_EDITION_REV0, const.CITY_EDITION_REV1):
             rec = self._get_record(ipnum)
-            country_code = rec['country_code'] if 'country_code' in rec else ''
-            region = rec['region_name'] if 'region_name' in rec else ''
+            country_code = rec['country_code'] if rec and 'country_code' in rec else ''
+            region = rec['region_name'] if rec and 'region_name' in rec else ''
 
         return {'country_code' : country_code, 'region_name' : region }
 


### PR DESCRIPTION
I have a wrapper :

class GeoIP:
      def **init**(self):
    self.geoip = pygeoip.GeoIP('<path to GeoLiteCity.dat>')
      def getCountry(self,ip):
    return self.geoip.country_code_by_addr(ip)

When I invoke it like so :
gp = GeoIP()
gp.getCountry('10.20.30.40')

I get :

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 5, in getCountry
  File "build/bdist.linux-x86_64/egg/pygeoip/**init**.py", line 429, in country_code_by_addr

  File "build/bdist.linux-x86_64/egg/pygeoip/**init**.py", line 587, in region_by_addr

  File "build/bdist.linux-x86_64/egg/pygeoip/**init**.py", line 294, in _get_region

TypeError: argument of type 'NoneType' is not iterable

The error is in line 294 of **init**.py that assumed that "rec" will not be None (which doesn't seem to be the case with many IPs i tested).
