### PR TITLE
Add support for non-gzipped .dat files when in MEMORY_CACHE mode.

### DIFF
--- a/pygeoip/__init__.py
+++ b/pygeoip/__init__.py
@@ -97,8 +97,12 @@ class GeoIP(GeoIPBase):
                 self._filehandle = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
 
         elif self._flags & const.MEMORY_CACHE:
-            self._filehandle = gzip.open(filename, 'rb')
-            self._memoryBuffer = self._filehandle.read()
+            try:
+                self._filehandle = gzip.open(filename, 'rb')
+                self._memoryBuffer = self._filehandle.read()
+            except IOError:
+                self._filehandle = codecs.open(filename, 'rb', 'latin_1')
+                self._memoryBuffer = self._filehandle.read()
 
         else:
             self._filehandle = codecs.open(filename, 'rb','latin_1')


### PR DESCRIPTION
Addresses appliedsec/pygeoip#5.

The recent change to allow gzipped .dat files when in MEMORY_CACHE mode _requires_ the .dat file to be gzipped. This was not the case in version 0.2.2. The changeset will allow both types of .dat files.
