### PR TITLE
Fix gzip in-memory feature, using StringIO to emulate file API for the parts that need it

### DIFF
--- a/pygeoip/__init__.py
+++ b/pygeoip/__init__.py
@@ -33,6 +33,7 @@ import math
 import socket
 import mmap
 import gzip
+from StringIO import StringIO
 
 from . import const
 from .util import ip2long
@@ -96,9 +97,14 @@ class GeoIP(GeoIPBase):
                 self._filehandle = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
 
         elif self._flags & const.MEMORY_CACHE:
-            self._filehandle = gzip.open(filename, 'rb')
-            self._memoryBuffer = self._filehandle.read()
+            if filename.endswith('.gz'):
+                opener = gzip.open
+            else:
+                opener = open
 
+            with opener(filename, 'rb') as f:
+                self._memoryBuffer = f.read()
+                self._filehandle = StringIO(self._memoryBuffer)
         else:
             self._filehandle = open(filename, 'rb')
 


### PR DESCRIPTION
This pull request fixes issue #7. My apologies for the previous buggy pull request.
