### PR TITLE
Ship metadata with source distribution to PyPI

### DIFF
--- a/MANIFEST.ini
+++ b/MANIFEST.ini
@@ -1,0 +1,8 @@
+recursive-include apidocs *
+recursive-include tests *
+include README.md
+include COPYING
+include DEVELOPER
+include INSTALL
+include epydoc.ini
+include tox.ini


### PR DESCRIPTION
By including a MANIFEST.in file, the next time you upload your source to PyPI, the tarball/zipfile should contain all of the meta-stuff in your project (tests, docs, files, etc.)

That is really nice for downstream people who aren't immediate end-users (like Linux distributions)  :)
