### PR TITLE
Add support for countries South Sudan and Bonaire, Sint Eustatius and Saba

### DIFF
--- a/pygeoip/const.py
+++ b/pygeoip/const.py
@@ -265,7 +265,8 @@ COUNTRY_CODES = (
     'SZ', 'TC', 'TD', 'TF', 'TG', 'TH', 'TJ', 'TK', 'TM', 'TN', 'TO', 'TL',
     'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'UM', 'US', 'UY', 'UZ', 'VA',
     'VC', 'VE', 'VG', 'VI', 'VN', 'VU', 'WF', 'WS', 'YE', 'YT', 'RS', 'ZA',
-    'ZM', 'ME', 'ZW', 'A1', 'A2', 'O1', 'AX', 'GG', 'IM', 'JE', 'BL', 'MF'
+    'ZM', 'ME', 'ZW', 'A1', 'A2', 'O1', 'AX', 'GG', 'IM', 'JE', 'BL', 'MF',
+    'BQ', 'SS'
 )
 
 COUNTRY_CODES3 = (
@@ -293,7 +294,7 @@ COUNTRY_CODES3 = (
     'TTO', 'TUV', 'TWN', 'TZA', 'UKR', 'UGA', 'UM', 'USA', 'URY', 'UZB', 'VAT',
     'VCT', 'VEN', 'VGB', 'VIR', 'VNM', 'VUT', 'WLF', 'WSM', 'YEM', 'YT', 'SRB',
     'ZAF', 'ZMB', 'MNE', 'ZWE', 'A1', 'A2', 'O1', 'ALA', 'GGY', 'IMN', 'JEY',
-    'BLM', 'MAF'
+    'BLM', 'MAF', 'BES', 'SSD'
 )
 
 COUNTRY_NAMES = (
@@ -353,7 +354,7 @@ COUNTRY_NAMES = (
     'Yemen', 'Mayotte', 'Serbia', 'South Africa', 'Zambia', 'Montenegro',
     'Zimbabwe', 'Anonymous Proxy', 'Satellite Provider', 'Other',
     'Aland Islands', 'Guernsey', 'Isle of Man', 'Jersey', 'Saint Barthelemy',
-    'Saint Martin'
+    'Saint Martin', 'Bonaire, Sint Eustatius and Saba', 'South Sudan, Republic of',
 )
 
 # storage / caching flags

--- a/tests/test_country.py
+++ b/tests/test_country.py
@@ -12,6 +12,7 @@ class TestGeoIPCountryFunctions(unittest.TestCase):
 
         self.us_ip = '64.233.161.99'
         self.gb_ip = '212.58.253.68'
+        self.ss_ip = '212.21.45.100'
 
         self.ie6_hostname = 'google.com'
         self.ie6_ip = '2a00:1450:400f:800::1002'
@@ -19,10 +20,12 @@ class TestGeoIPCountryFunctions(unittest.TestCase):
         self.ie_code = 'IE'
         self.us_code = 'US'
         self.gb_code = 'GB'
+        self.ss_code = 'SS'
 
         self.ie_name = 'Ireland'
         self.us_name = 'United States'
         self.gb_name = 'United Kingdom'
+        self.ss_name = 'South Sudan, Republic of'
 
         self.gi = pygeoip.GeoIP(COUNTRY_DB_PATH)
         self.gi6 = pygeoip.GeoIP(COUNTRY_V6_DB_PATH)
@@ -39,10 +42,12 @@ class TestGeoIPCountryFunctions(unittest.TestCase):
     def testCountryCodeByAddr(self):
         us_code = self.gi.country_code_by_addr(self.us_ip)
         gb_code = self.gi.country_code_by_addr(self.gb_ip)
+        ss_code = self.gi.country_code_by_addr(self.ss_ip)
         ie6_code = self.gi6.country_code_by_addr(self.ie6_ip)
         
         self.assertEqual(us_code, self.us_code)
         self.assertEqual(gb_code, self.gb_code)
+        self.assertEqual(ss_code, self.ss_code)
         self.assertEqual(ie6_code, self.ie_code)
 
     def testCountryNameByName(self):
@@ -57,8 +62,10 @@ class TestGeoIPCountryFunctions(unittest.TestCase):
     def testCountryNameByAddr(self):
         us_name = self.gi.country_name_by_addr(self.us_ip)
         gb_name = self.gi.country_name_by_addr(self.gb_ip)
+        ss_name = self.gi.country_name_by_addr(self.ss_ip)
         ie6_name = self.gi6.country_name_by_addr(self.ie6_ip)
 
         self.assertEqual(us_name, self.us_name)
         self.assertEqual(gb_name, self.gb_name)
+        self.assertEqual(ss_name, self.ss_name)
         self.assertEqual(ie6_name, self.ie_name)


### PR DESCRIPTION
Lines 345-347 of __init__.py (_get_record) throw an exception if these countries are missing from const.COUNTRY_CODES, const.COUNTRY_CODES3, const.COUNTRY_NAMES.
