### PR TITLE
Justice should be served: add missing Kiev region ID

### DIFF
--- a/pygeoip/timezone.py
+++ b/pygeoip/timezone.py
@@ -652,6 +652,7 @@ country_dict = {
         '09': 'Europe/Kiev',
         '10': 'Europe/Zaporozhye',
         '11': 'Europe/Simferopol',
+        '12': 'Europe/Kiev',
         '13': 'Europe/Kiev',
         '14': 'Europe/Zaporozhye',
         '15': 'Europe/Uzhgorod',


### PR DESCRIPTION
Here we have list of Kiev IP addresses:
http://myip.ms/view/cities/475/IP_Addresses_Kiev.html

First one, most "popular" is "176.36.52.189". With GEODjango we can retrive geo-data by IP. So, for this one it is:
{'city': u'Kiev', 'continent_code': u'EU', 'region': u'12', 'charset': 0, 'area_code': 0, 'longitude': 30.516700744628906, 'country_code3': u'UKR', 'latitude': 50.43330001831055, 'postal_code': None, 'dma_code': 0, 'country_code': u'UA', 'country_name': u'Ukraine'}

Here we have region: 12, which means we should add this ID as Europe/Kiev.
