### PR TITLE
Add PyPi upload date for release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix: Improved exception handling (Thanks to Oliver Keyes)
 * Fix: Return country for region lookups outside US and CA
 
-Not yet uploaded to PyPi
+Uploaded to PyPi on 2014-10-28
 
 ### Release 0.3.1
 


### PR DESCRIPTION
As according to https://pypi.python.org/pypi/pygeoip/