### PR TITLE
return {} instead of None when record not found

### DIFF
--- a/pygeoip/__init__.py
+++ b/pygeoip/__init__.py
@@ -546,7 +546,7 @@ class GeoIP(object):
         ipnum = util.ip2long(addr)
         rec = self._get_record(ipnum)
         if not rec:
-            return None
+            return {}
 
         return rec
 


### PR DESCRIPTION
country_name_by_addr(addr) fails when the record is not found:  
/usr/local/lib/python2.7/dist-packages/pygeoip/__init__.pyc in country_name_by_addr(self, addr)
    489             return const.COUNTRY_NAMES[country_id]
    490         elif self._databaseType in const.CITY_EDITIONS:
--> 491             return self.record_by_addr(addr).get('country_name')
    492         else:
    493             message = 'Invalid database type, expected Country or City'

AttributeError: 'NoneType' object has no attribute 'get'

In a previous version (0.2.6) that doesn't fail when a record is not found 
record_by_addr(addr) returns {} instead of None.